### PR TITLE
fix(release): commit dist files before creating release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,19 @@ jobs:
       - name: Build action
         run: npm run build
 
+      - name: Commit dist files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            git add dist/
+            git commit -m "build: compile distribution files for release"
+            echo "✅ Distribution files committed"
+          else
+            echo "ℹ️  No changes to distribution files"
+          fi
+
       - name: Determine version
         id: version
         run: |
@@ -244,6 +257,12 @@ jobs:
           
           # Set output for release creation
           echo "notes_file=release-notes.md" >> $GITHUB_OUTPUT
+
+      - name: Push changes to main
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          # Push any commits (dist files, version updates) before tagging
+          git push origin main
 
       - name: Create Git tag
         if: steps.check_tag.outputs.exists == 'false'

--- a/scripts/verify-versions.sh
+++ b/scripts/verify-versions.sh
@@ -56,8 +56,8 @@ fi
 
 echo "🔍 Scanning for version references..."
 
-# Find all version references  
-ALL_REFS_RAW=$(find examples/ README.md RELEASES.md -type f 2>/dev/null -exec grep -Hn "baires/ai-release-notes-action@v[0-9]*\(\.[0-9]*\.[0-9]*\)\?" {} \; | sort)
+# Find all version references (excluding sed patterns in documentation)
+ALL_REFS_RAW=$(find examples/ README.md RELEASES.md -type f 2>/dev/null -exec grep -Hn "baires/ai-release-notes-action@v[0-9]*\(\.[0-9]*\.[0-9]*\)\?" {} \; | grep -v "sed -i" | sort)
 
 # Also check for GitHub URL references in source code
 SRC_REFS_RAW=$(find src/ -name "*.js" -type f 2>/dev/null -exec grep -Hn "github.com/baires/ai-release-notes-action" {} \; | sort || true)


### PR DESCRIPTION
Ensure distribution files are committed to the repository before tags are created. This allows GitHub Actions to reference the action by tag (e.g., @v1, @v1.0.2) without encountering missing dist/index.js errors.

Changes:
- Add step to commit dist files after build
- Push commits to main before creating tags
- Fix version verification script to exclude sed patterns

Resolves issue where users get "File not found: dist/index.js" when referencing the action by version tag.